### PR TITLE
Tune hyperparameters of DQN and fix bug

### DIFF
--- a/dqn_envpool.py
+++ b/dqn_envpool.py
@@ -25,22 +25,22 @@ flags.DEFINE_integer("eval_episodes", 50, "Number of evaluation episodes.")
 flags.DEFINE_integer("evaluate_every", 2_000, "Number of episodes between evaluations.")
 
 # optimizer configs
-flags.DEFINE_float("learning_rate", 0.0001, "Optimizer learning rate.")
+flags.DEFINE_float("learning_rate", 0.0003, "Optimizer learning rate.")
 
 # network configs
 flags.DEFINE_integer("batch_size", 64, "Size of the training batch")
-flags.DEFINE_integer("replay_capacity", 5000, "Capacity of the replay buffer.")
+flags.DEFINE_integer("replay_capacity", 1_000_000, "Capacity of the replay buffer.")
 flags.DEFINE_list("hidden_units", [64, 64], "Number of network hidden units.")
 
 # RL configs
-flags.DEFINE_float("target_period", 3000, "How often to update the target net.")
+flags.DEFINE_float("target_period", 10, "How often to update the target net.")
 flags.DEFINE_float("discount_factor", 0.99, "Q-learning discount factor.")
-flags.DEFINE_float("epsilon_begin", 1., "Initial epsilon-greedy exploration.")
+flags.DEFINE_float("epsilon_begin", .5, "Initial epsilon-greedy exploration.")
 flags.DEFINE_float("epsilon_end", 0.05, "Final epsilon-greedy exploration.")
-flags.DEFINE_integer("epsilon_steps", 100_000, "Steps over which to anneal eps.")
+flags.DEFINE_integer("epsilon_steps", 2_000, "Steps over which to anneal eps.")
 
 # env configs
-flags.DEFINE_string("env", "CartPole-v0", "Name of the OpenAI Gym environment to use.")
+flags.DEFINE_string("env", "CartPole-v1", "Name of the OpenAI Gym environment to use.")
 flags.DEFINE_integer("num_envs", 20, "Number of environments to use.")
 
 

--- a/utils/network.py
+++ b/utils/network.py
@@ -1,7 +1,8 @@
 import haiku as hk
 from haiku import nets
+from typing import List
 
-def build_network(num_actions: int, hidden_dims: list[int] ) -> hk.Transformed:
+def build_network(num_actions: int, hidden_dims: List[int] ) -> hk.Transformed:
     """Factory for a simple MLP network for approximating Q-values."""
 
     def q(obs):


### PR DESCRIPTION
On CartPole-v1,  DQN with the original hyperparameters can achieve a return up to ~200. But with the tuned hyperparameters, it can get 500 and be much more stable. I mainly change the hyperparameters in the following ways:

1. increase the learning rate to $3e^{-4}$, the best learning rate of Adam;
2. decrease the target update frequency, making the target not too different from the current network;
3. increase the buffer size, to store much more samples to improve the evaluation accuracy and sample efficiency;
4. change the epsilon schedule, including decreasing the epsilon_begin and the epsilon_steps. In fact, CartPole does not need such aggressive exploration. And I guess the reason why the original DQN performs not well is the totally random actions in the buffer for long timesteps, indeed caused by the epsilon schedule and small buffer.